### PR TITLE
Changing the names to improve consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Be Kurdi (بە کوردی)
+
 Kurdish language is being written in three main alphabets: [Sorani Alphabet, Latin Alphabet And Crylic Alphabet](https://en.wikipedia.org/wiki/Kurdish_alphabets). This library provides a simple way to convert bodies of text between the different alphabets.
 
-# [Install Nuget Package:] [![NuGet](https://img.shields.io/nuget/v/DevTree.BeKurdi.svg)](https://www.nuget.org/packages/DevTree.BeKurdi/)
+## How to use [![NuGet](https://img.shields.io/nuget/v/DevTree.BeKurdi.svg)](https://www.nuget.org/packages/DevTree.BeKurdi/)
+First add the [nuget package](https://www.nuget.org/packages/DevTree.BeKurdi/) to your project:
 ```
 PM> Install-Package DevTree.BeKurdi
+```
+
+Then add this using statement to the top of the class:
+```csharp
+using DevTree.BeKurdi;
+```
+
+Now you can normalize Sorani text like this:
+```csharp
+var text = "ضؤني";
+var normalized = text.ToStandardSorani(); // will be converted to: چۆنی
 ```
 
 ## State of the project
@@ -15,12 +28,12 @@ This project is at its very early stages, but we do welcome contribution from ev
  - Helping us to spread the word
  
 ### Build Status
- - dev: [![Build Status](https://travis-ci.org/DevelopersTree/BeKurdi.svg?branch=dev)](https://travis-ci.org/DevelopersTree/BeKurdi)
  - master: [![Build Status](https://travis-ci.org/DevelopersTree/BeKurdi.svg?branch=master)](https://travis-ci.org/DevelopersTree/BeKurdi)
+ - dev: [![Build Status](https://travis-ci.org/DevelopersTree/BeKurdi.svg?branch=dev)](https://travis-ci.org/DevelopersTree/BeKurdi)
 
- ## Resources
+## Resources
   - [ڕێنووسی زمانی کوردی](http://diyako.yageyziman.com/%DA%95%DB%8E%D9%86%D9%88%D9%88%D8%B3/)
   - [پڕۆژەی پەڵک کوردی‌نووس](http://chawg.org/kurdi-nus/)
 
- ## Licence
- This project is developed under [MIT License](LICENSE).
+## Licence
+This project is being developed under [MIT License](LICENSE).

--- a/src/DevTree.BeKurdi.Demo/NormalizationBenchmark.cs
+++ b/src/DevTree.BeKurdi.Demo/NormalizationBenchmark.cs
@@ -35,13 +35,13 @@ namespace DevTree.BeKurdi.Demo
         [Benchmark]
         public string Normalize10M()
         {
-            return SoraniNormalization.Normalize(Text10M);
+            return Sorani.Normalize(Text10M);
         }
 
         [Benchmark]
         public string Normalize1M()
         {
-            return SoraniNormalization.Normalize(Text1M);
+            return Sorani.Normalize(Text1M);
         }
 
         public string RegexReplace()

--- a/src/DevTree.BeKurdi/DevTree.BeKurdi.csproj
+++ b/src/DevTree.BeKurdi/DevTree.BeKurdi.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.4.0</Version>
+    <Version>0.0.5.0</Version>
     <Authors>Muhammad Azeez</Authors>
     <Company>Developers Tree</Company>
     <Description>A .Net library to convert Kurdish text between different alphabets</Description>
@@ -11,8 +11,8 @@
     <PackageProjectUrl>https://github.com/DevelopersTree/BeKurdi</PackageProjectUrl>
     <RepositoryUrl>https://github.com/DevelopersTree/BeKurdi</RepositoryUrl>
     <PackageTags>Kurdish, lingusitics, alphabet</PackageTags>
-    <PackageReleaseNotes>+ Added Sorani Normalization
- + Some breaking changes to Unicode class</PackageReleaseNotes>
+    <PackageReleaseNotes>+ Fix a bug where SoraniLam + Kasra wouldn't be replaced with SoraniHeavyLam
+ + Changing the names to be hopefully more consistent</PackageReleaseNotes>
 
   </PropertyGroup>
   

--- a/src/DevTree.BeKurdi/SoraniNormalization.cs
+++ b/src/DevTree.BeKurdi/SoraniNormalization.cs
@@ -25,6 +25,8 @@ namespace DevTree.BeKurdi
 
             builder.Replace($"{Reh}{ArabicKasra}", $"{RehWithSmallV}");
 
+            builder.Replace($"{Lam}{ArabicFatha}", $"{LamWithSmallV}");
+
             builder.Replace(ArabicLetterTah, Gaf)
                    .Replace(ArabicLetterKaf, Kaf)
                    .Replace(ArabicLetterDad, Tcheh)
@@ -45,7 +47,7 @@ namespace DevTree.BeKurdi
             while (endIndex < builder.Length)
             {
                 endIndex = builder.Length - startIndex <= MaxWordLength ? builder.Length : endIndex;
-                bool exitLoop = endIndex > 0;
+                bool exitLoop = endIndex == builder.Length;
                 while ((endIndex - startIndex) < MaxWordLength && endIndex < builder.Length)
                 {
                     switch (builder[endIndex])
@@ -118,7 +120,6 @@ namespace DevTree.BeKurdi
         {
             if (builder[startIndex] == Reh)
                 builder[startIndex] = RehWithSmallV;
-
 
             return 0;
         }

--- a/src/DevTree.BeKurdi/SoraniNormalization.cs
+++ b/src/DevTree.BeKurdi/SoraniNormalization.cs
@@ -12,6 +12,9 @@ namespace DevTree.BeKurdi
 
         public static string Normalize(this string text)
         {
+            if (text is null) throw new ArgumentNullException(nameof(text));
+            if (text.Length == 0) return text;
+
             var builder = new StringBuilder(text);
 
             // Simple replacements
@@ -100,7 +103,7 @@ namespace DevTree.BeKurdi
             {
                 if (builder[i] != Hamza)
                     continue;
-                
+
                 // A valid hamza has the following properties:
                 //  - It's usually at the beginning of the word
                 //  - It's never at the end of the word

--- a/src/DevTree.BeKurdi/Unicode.cs
+++ b/src/DevTree.BeKurdi/Unicode.cs
@@ -13,199 +13,199 @@ namespace DevTree.BeKurdi
         /// <para>Standard Sorani letter: <code>ئ</code> - <code>U+0626</code> </para>
         /// <para>Unicode Name: ARABIC LETTER YEH WITH HAMZA ABOVE </para>
         /// </summary>
-        public const char Hamza = '\u0626';
+        public const char SoraniHamza = '\u0626';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ا</code> - <code>U+0627</code> </para>
         /// <para>Unicode Name: ARABIC LETTER ALEF </para>
         /// </summary>
-        public const char Alef = '\u0627';
+        public const char SoraniAlef = '\u0627';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ب</code> - <code>U+0628</code> </para>
         /// <para>Unicode Name: ARABIC LETTER BEH </para>
         /// </summary>
-        public const char Beh = '\u0628';
+        public const char SoraniBeh = '\u0628';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>پ</code> - <code>U+067E</code> </para>
         /// <para>Unicode Name: ARABIC LETTER PEH </para>
         /// </summary>
-        public const char Peh = '\u067E';
+        public const char SoraniPeh = '\u067E';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ت</code> - <code>U+062A</code> </para>
         /// <para>Unicode Name: ARABIC LETTER TEH </para>
         /// </summary>
-        public const char Teh = '\u062A';
+        public const char SoraniTeh = '\u062A';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ج</code> - <code>U+062C</code> </para>
         /// <para>Unicode Name: ARABIC LETTER JEEM </para>
         /// </summary>
-        public const char Jeem = '\u062C';
+        public const char SoraniJeem = '\u062C';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>چ</code> - <code>U+0686</code> </para>
         /// <para>Unicode Name: ARABIC LETTER TCHEH </para>
         /// </summary>
-        public const char Tcheh = '\u0686';
+        public const char SoraniCheem = '\u0686';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ح</code> - <code>U+062D</code> </para>
         /// <para>Unicode Name: ARABIC LETTER HAH </para>
         /// </summary>
-        public const char Hah = '\u062D';
+        public const char SoraniHah = '\u062D';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>خ</code> - <code>U+062E</code> </para>
         /// <para>Unicode Name: ARABIC LETTER KHAH </para>
         /// </summary>
-        public const char Khah = '\u062E';
+        public const char SoraniKhah = '\u062E';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>د</code> - <code>U+062F</code> </para>
         /// <para>Unicode Name: ARABIC LETTER DAL </para>
         /// </summary>
-        public const char Dal = '\u062F';
+        public const char SoraniDal = '\u062F';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ر</code> - <code>U+0631</code> </para>
         /// <para>Unicode Name: ARABIC LETTER REH </para>
         /// </summary>
-        public const char Reh = '\u0631';
+        public const char SoraniReh = '\u0631';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ڕ</code> - <code>U+0695</code> </para>
         /// <para>Unicode Name: ARABIC LETTER REH WITH SMALL V BELOW </para>
         /// </summary>
-        public const char RehWithSmallV = '\u0695';
+        public const char SoraniHeavyReh = '\u0695';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ز</code> - <code>U+0632</code> </para>
         /// <para>Unicode Name: ARABIC LETTER ZAIN </para>
         /// </summary>
-        public const char Zain = '\u0632';
+        public const char SoraniZeh = '\u0632';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ژ</code> - <code>U+0698</code> </para>
         /// <para>Unicode Name: ARABIC LETTER JEH </para>
         /// </summary>
-        public const char Jeh = '\u0698';
+        public const char SoraniJeh = '\u0698';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>س</code> - <code>U+0633</code> </para>
         /// <para>Unicode Name: ARABIC LETTER SEEN </para>
         /// </summary>
-        public const char Seen = '\u0633';
+        public const char SoraniSeen = '\u0633';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ش</code> - <code>U+0634</code> </para>
         /// <para>Unicode Name: ARABIC LETTER SHEEN </para>
         /// </summary>
-        public const char Sheen = '\u0634';
+        public const char SoraniSheen = '\u0634';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ع</code> - <code>U+0639</code> </para>
         /// <para>Unicode Name: ARABIC LETTER AIN </para>
         /// </summary>
-        public const char Ain = '\u0639';
+        public const char SoraniAin = '\u0639';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>غ</code> - <code>U+063A</code> </para>
         /// <para>Unicode Name: ARABIC LETTER GHAIN </para>
         /// </summary>
-        public const char Ghain = '\u063A';
+        public const char SoraniGhain = '\u063A';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ف</code> - <code>U+0641</code> </para>
         /// <para>Unicode Name: ARABIC LETTER FEH </para>
         /// </summary>
-        public const char Feh = '\u0641';
+        public const char SoraniFeh = '\u0641';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ڤ</code> - <code>U+06A4</code> </para>
         /// <para>Unicode Name: ARABIC LETTER VEH </para>
         /// </summary>
-        public const char Veh = '\u06A4';
+        public const char SoraniVeh = '\u06A4';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ق</code> - <code>U+0642</code> </para>
         /// <para>Unicode Name: ARABIC LETTER QAF </para>
         /// </summary>
-        public const char Qaf = '\u0642';
+        public const char SoraniQaf = '\u0642';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ک</code> - <code>U+06A9</code> </para>
         /// <para>Unicode Name: ARABIC LETTER KEHEH </para>
         /// </summary>
-        public const char Kaf = '\u06A9';
+        public const char SoraniKaf = '\u06A9';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>گ</code> - <code>U+06AF</code> </para>
         /// <para>Unicode Name: ARABIC LETTER GAF </para>
         /// </summary>
-        public const char Gaf = '\u06AF';
+        public const char SoraniGaf = '\u06AF';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ل</code> - <code>U+0644</code> </para>
         /// <para>Unicode Name: ARABIC LETTER LAM </para>
         /// </summary>
-        public const char Lam = '\u0644';
+        public const char SoraniLam = '\u0644';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ڵ</code> - <code>U+06B5</code> </para>
         /// <para>Unicode Name: ARABIC LETTER LAM WITH SMALL V </para>
         /// </summary>
-        public const char LamWithSmallV = '\u06B5';
+        public const char SoraniHeavyLam = '\u06B5';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>م</code> - <code>U+0645</code> </para>
         /// <para>Unicode Name: ARABIC LETTER MEEM </para>
         /// </summary>
-        public const char Meem = '\u0645';
+        public const char SoraniMeem = '\u0645';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ن</code> - <code>U+0646</code> </para>
         /// <para>Unicode Name: ARABIC LETTER NOON </para>
         /// </summary>
-        public const char Noon = '\u0646';
+        public const char SoraniNoon = '\u0646';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>و</code> - <code>U+0648</code> </para>
         /// <para>Unicode Name: ARABIC LETTER WAW </para>
         /// </summary>
-        public const char Waw = '\u0648';
+        public const char SoraniWaw = '\u0648';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ۆ</code> - <code>U+06C6</code> </para>
         /// <para>Unicode Name: ARABIC LETTER OE </para>
         /// </summary>
-        public const char Oe = '\u06C6';
+        public const char SoraniOe = '\u06C6';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ه، هـ</code> - <code>U+0647</code> </para>
         /// <para>Unicode Name: ARABIC LETTER HEH </para>
         /// </summary>
-        public const char Heh = '\u0647';
+        public const char SoraniHeh = '\u0647';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ە، ـە</code> - <code>U+06D5</code> </para>
         /// <para>Unicode Name: ARABIC LETTER AE </para>
         /// </summary>
-        public const char Ae = '\u06D5';
+        public const char SoraniAe = '\u06D5';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ی</code> - <code>U+06CC</code> </para>
         /// <para>Unicode Name: ARABIC LETTER FARSI YEH </para>
         /// </summary>
-        public const char Yeh = '\u06CC';
+        public const char SoraniYeh = '\u06CC';
 
         /// <summary>
         /// <para>Standard Sorani letter: <code>ێ</code> - <code>U+06CE</code> </para>
         /// <para>Unicode Name: ARABIC LETTER YEH WITH SMALL V </para>
         /// </summary>
-        public const char YehWithSmallV = '\u06CE';
+        public const char SoraniOpenYeh = '\u06CE';
         #endregion // Standard Sorani
 
         #region Sorani Numbers
@@ -319,43 +319,43 @@ namespace DevTree.BeKurdi
         /// <para>Non-Standard Sorani letter: <code>أ</code> - <code>U+0623</code> </para>
         /// <para>Unicode Name: ARABIC LETTER ALEF WITH HAMZA ABOVE </para>
         /// </summary>
-        public const char ArabicLetterAlefWithHamzaAbove = '\u0623';
+        public const char ArabicAlefWithHamzaAbove = '\u0623';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>آ</code> - <code>U+0622</code> </para>
         /// <para>Unicode Name: ARABIC LETTER ALEF WITH MADDA ABOVE </para>
         /// </summary>
-        public const char ArabicLetterAlefWithMaddaAbove = '\u0622';
+        public const char ArabicAlefWithMaddaAbove = '\u0622';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ض</code> - <code>U+0636</code> </para>
         /// <para>Unicode Name: ARABIC LETTER DAD </para>
         /// </summary>
-        public const char ArabicLetterDad = '\u0636';
+        public const char ArabicDad = '\u0636';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ث</code> - <code>U+062B</code> </para>
         /// <para>Unicode Name: ARABIC LETTER THEH </para>
         /// </summary>
-        public const char ArabicLetterTheh = '\u062B';
+        public const char ArabicTheh = '\u062B';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ظ</code> - <code>U+0638</code> </para>
         /// <para>Unicode Name: ARABIC LETTER ZAH </para>
         /// </summary>
-        public const char ArabicLetterZah = '\u0638';
+        public const char ArabicLZah = '\u0638';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ي</code> - <code>U+064A</code> </para>
         /// <para>Unicode Name: ARABIC LETTER YEH </para>
         /// </summary>
-        public const char ArabicLetterYeh = '\u064A';
+        public const char ArabicYeh = '\u064A';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ى</code> - <code>U+0649</code> </para>
         /// <para>Unicode Name: ARABIC LETTER ALEF MAKSURA </para>
         /// </summary>
-        public const char ArabicLetterAlefMaksura = '\u0649';
+        public const char ArabicAlefMaksura = '\u0649';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ِ</code> - <code>U+0650</code> </para>
@@ -367,25 +367,25 @@ namespace DevTree.BeKurdi
         /// <para>Non-Standard Sorani letter: <code>ؤ</code> - <code>U+0624</code> </para>
         /// <para>Unicode Name: ARABIC LETTER WAW WITH HAMZA ABOVE </para>
         /// </summary>
-        public const char ArabicLetterWawWithHamzaAbove = '\u0624';
+        public const char ArabicWawWithHamzaAbove = '\u0624';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ذ</code> - <code>U+0630</code> </para>
         /// <para>Unicode Name: ARABIC LETTER THAL </para>
         /// </summary>
-        public const char ArabicLetterThal = '\u0630';
+        public const char ArabicThal = '\u0630';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ك</code> - <code>U+0643</code> </para>
         /// <para>Unicode Name: ARABIC LETTER KAF </para>
         /// </summary>
-        public const char ArabicLetterKaf = '\u0643';
+        public const char ArabicKaf = '\u0643';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ھ</code> - <code>U+06BE</code> </para>
         /// <para>Unicode Name: ARABIC LETTER HEH DOACHASHMEE </para>
         /// </summary>
-        public const char ArabicLetterHehDoachashmee = '\u06BE';
+        public const char ArabicHehDoachashmee = '\u06BE';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>‌</code> - <code>U+200C</code> </para>
@@ -397,19 +397,19 @@ namespace DevTree.BeKurdi
         /// <para>Non-Standard Sorani letter: <code>ة</code> - <code>U+0629</code> </para>
         /// <para>Unicode Name: ARABIC LETTER TEH MARBUTA </para>
         /// </summary>
-        public const char ArabicLetterTehMarbuta = '\u0629';
+        public const char ArabicTehMarbuta = '\u0629';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ص</code> - <code>U+0635</code> </para>
         /// <para>Unicode Name: ARABIC LETTER SAD </para>
         /// </summary>
-        public const char ArabicLetterSad = '\u0635';
+        public const char ArabicSad = '\u0635';
 
         /// <summary>
         /// <para>Non-Standard Sorani letter: <code>ط</code> - <code>U+0635</code> </para>
         /// <para>Unicode Name: ARABIC LETTER TAH </para>
         /// </summary>
-        public const char ArabicLetterTah = '\u0637';
+        public const char ArabicTah = '\u0637';
         #endregion // Non-Standard Sorani
 
         #region Common Symbols
@@ -727,14 +727,16 @@ namespace DevTree.BeKurdi
         /// </summary>
         public static IReadOnlyList<char> SoraniAlphabet => new List<char>
         {
-            Hamza,          Alef,   Beh,    Peh,    Teh,    Jeem,   Tcheh,  Hah,    Khah,   Dal,    Reh,    RehWithSmallV,
-            Zain,           Jeh,    Seen,   Sheen,  Ain,    Ghain,  Feh,    Veh,    Qaf,    Kaf,  Gaf,    Lam,
-            LamWithSmallV,  Meem,   Noon,   Waw,    Oe,     Ae,     Heh,    Yeh,    YehWithSmallV
+            SoraniHamza,    SoraniAlef,     SoraniBeh,      SoraniPeh,      SoraniTeh,      SoraniJeem,     SoraniCheem,
+            SoraniHah,      SoraniKhah,     SoraniDal,      SoraniReh,      SoraniHeavyReh, SoraniZeh,      SoraniJeh,
+            SoraniSeen,     SoraniSheen,    SoraniAin,      SoraniGhain,    SoraniFeh,      SoraniVeh,      SoraniQaf,
+            SoraniKaf,      SoraniGaf,      SoraniLam,      SoraniHeavyLam, SoraniMeem,     SoraniNoon,     SoraniWaw,
+            SoraniOe,       SoraniAe,       SoraniHeh,      SoraniYeh,      SoraniOpenYeh
         };
 
         public static IReadOnlyList<char> SoraniAlphabetVowels => new List<char>
         {
-            Alef, Waw, Oe, Ae, Yeh, YehWithSmallV
+            SoraniAlef, SoraniWaw, SoraniOe, SoraniAe, SoraniYeh, SoraniOpenYeh
         };
 
         /// <summary>
@@ -752,8 +754,8 @@ namespace DevTree.BeKurdi
         /// </summary>
         public static IReadOnlyList<char> SoraniPunctuation => new List<char>
         {
-            FullStop, Colon, SoraniComma, SoraniDash, RightParenthesis, LeftParenthesis, SoraniRightQuotationMark, SoraniLeftQuotationMark,
-            ExclamationMark, SoraniQuestionMark, SoraniSemicolon, Slash, BackSlash, Comma, Hyphen, Space
+            FullStop, Colon, SoraniComma, SoraniDash, RightParenthesis, LeftParenthesis, SoraniRightQuotationMark,
+            SoraniLeftQuotationMark, ExclamationMark, SoraniQuestionMark, SoraniSemicolon, Slash, BackSlash, Comma, Hyphen, Space
         };
 
         /// <summary>
@@ -772,16 +774,16 @@ namespace DevTree.BeKurdi
         /// </summary>
         public static IReadOnlyList<char> NonStandardSoraniAlphabet => new List<char>
         {
-            ArabicFatha,        ArabicLetterAlefWithHamzaAbove,     ArabicLetterAlefWithMaddaAbove,     ArabicLetterDad,
-            ArabicLetterTheh,   ArabicLetterTah,                    ArabicLetterYeh,                    ArabicKasra,
-            ArabicLetterThal,   ArabicLetterWawWithHamzaAbove,      ArabicLetterHehDoachashmee,         ArabicLetterAlefMaksura,
-            ArabicLetterKaf,    ZeroWidthNonJoiner,                 ArabicLetterTehMarbuta,             ArabicLetterSad,
+            ArabicFatha,    ArabicAlefWithHamzaAbove,   ArabicAlefWithMaddaAbove,     ArabicDad,
+            ArabicTheh,     ArabicTah,                  ArabicYeh,                    ArabicKasra,
+            ArabicThal,     ArabicWawWithHamzaAbove,    ArabicHehDoachashmee,         ArabicAlefMaksura,
+            ArabicKaf,      ZeroWidthNonJoiner,         ArabicTehMarbuta,             ArabicSad,
         };
 
         public static IReadOnlyList<char> NonStandardSoraniAlphabetVowels => new List<char>
         {
-            ArabicLetterAlefWithHamzaAbove, ArabicLetterAlefWithMaddaAbove, ArabicLetterYeh,        ArabicLetterWawWithHamzaAbove,
-            ArabicLetterWawWithHamzaAbove,  ArabicLetterAlefMaksura,        ArabicLetterTehMarbuta,
+            ArabicAlefWithHamzaAbove, ArabicAlefWithMaddaAbove, ArabicYeh,        ArabicWawWithHamzaAbove,
+            ArabicWawWithHamzaAbove,  ArabicAlefMaksura,        ArabicTehMarbuta,
         };
 
         private static IReadOnlyList<char> _allSoraniAlphabetVowls = SoraniAlphabetVowels.Union(NonStandardSoraniAlphabetVowels).ToList();

--- a/tests/DevTree.BeKurdi.Tests/SoraniNormalizationTests.cs
+++ b/tests/DevTree.BeKurdi.Tests/SoraniNormalizationTests.cs
@@ -13,7 +13,7 @@ namespace DevTree.BeKurdi.Tests
         [Fact]
         public void Should_Return_Empty_String_When_Given_Empty_String()
         {
-            var normalized = SoraniNormalization.Normalize(string.Empty);
+            var normalized = Sorani.ToStandardSorani(string.Empty);
             Assert.Equal(string.Empty, normalized);
         }
 
@@ -21,191 +21,191 @@ namespace DevTree.BeKurdi.Tests
         public void Passing_Null_Should_Throw_Exception()
         {
             Assert.Throws<ArgumentNullException>(() =>
-            SoraniNormalization.Normalize(null));
+            Sorani.ToStandardSorani(null));
         }
 
         [Theory]
-        [InlineData(Reh)]                                   // ر => ڕ
-        [InlineData(Reh, YehWithSmallV, Waw, Yeh)]          // رێوی => ڕێوی
+        [InlineData(SoraniReh)]                                               // ر => ڕ
+        [InlineData(SoraniReh, SoraniOpenYeh, SoraniWaw, SoraniYeh)]          // رێوی => ڕێوی
         public void Should_Change_Initial_r_To_R(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.Equal(RehWithSmallV, normalized[0]);
+            Assert.Equal(SoraniHeavyReh, normalized[0]);
         }
 
         [Theory]
-        [InlineData(Jeem, Alef, Reh)]                       // جار
-        [InlineData(Seen, Ae, Reh, Dal, Alef, Reh)]         // سەردار
+        [InlineData(SoraniJeem, SoraniAlef, SoraniReh)]                                         // جار
+        [InlineData(SoraniSeen, SoraniAe, SoraniReh, SoraniDal, SoraniAlef, SoraniReh)]         // سەردار
         public void Should_Not_Change_Medial_r_To_R(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
             Assert.Equal(text, normalized);
         }
 
         [Theory]
-        [InlineData(ArabicLetterDad, Tcheh)]                            // ض => چ
-        [InlineData(ArabicLetterThal, Jeh)]                             // ذ => ژ
-        [InlineData(ArabicLetterZah, Veh)]                              // ظ => ڤ
-        [InlineData(ArabicLetterTheh, Peh)]                             // ث => پ
-        [InlineData(ArabicLetterTah, Gaf)]                              // ط => گ
-        [InlineData(ArabicLetterKaf, Kaf)]                              // ك => ک
-        [InlineData(ArabicLetterHehDoachashmee, Heh)]                   // ه‍ => ه 
-        [InlineData(ArabicLetterTehMarbuta, Ae)]                        // ة => ە
-        [InlineData(ArabicLetterWawWithHamzaAbove, Oe)]                 // ؤ => ۆ
-        [InlineData(ArabicLetterAlefMaksura, Yeh)]                      // ى => ی
-        [InlineData(ArabicLetterYeh, Yeh)]                              // ي => ی
-        [InlineData(ArabicLetterAlefWithHamzaAbove, Alef)]              // أ => ا
-        [InlineData(ArabicLetterAlefWithMaddaAbove, Alef)]              // آ => ا
+        [InlineData(ArabicDad, SoraniCheem)]                            // ض => چ
+        [InlineData(ArabicThal, SoraniJeh)]                             // ذ => ژ
+        [InlineData(ArabicLZah, SoraniVeh)]                             // ظ => ڤ
+        [InlineData(ArabicTheh, SoraniPeh)]                             // ث => پ
+        [InlineData(ArabicTah, SoraniGaf)]                              // ط => گ
+        [InlineData(ArabicKaf, SoraniKaf)]                              // ك => ک
+        [InlineData(ArabicHehDoachashmee, SoraniHeh)]                   // ه‍ => ه 
+        [InlineData(ArabicTehMarbuta, SoraniAe)]                        // ة => ە
+        [InlineData(ArabicWawWithHamzaAbove, SoraniOe)]                 // ؤ => ۆ
+        [InlineData(ArabicAlefMaksura, SoraniYeh)]                      // ى => ی
+        [InlineData(ArabicYeh, SoraniYeh)]                              // ي => ی
+        [InlineData(ArabicAlefWithHamzaAbove, SoraniAlef)]              // أ => ا
+        [InlineData(ArabicAlefWithMaddaAbove, SoraniAlef)]              // آ => ا
         public void Should_Replace_Non_Standard_Char(char find, char replace)
         {
             var text = find.ToString();
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
             Assert.True(normalized == replace.ToString());
 
-            text = $"{Alef}{find}";
+            text = $"{SoraniAlef}{find}";
             AssertSimpleSoraniNormalizer(text, find, replace);
 
-            text = $"{find}{Alef}";
+            text = $"{find}{SoraniAlef}";
             AssertSimpleSoraniNormalizer(text, find, replace);
 
-            text = $"{Beh}{find}";
+            text = $"{SoraniBeh}{find}";
             AssertSimpleSoraniNormalizer(text, find, replace);
 
-            text = $"{find}{Beh}";
+            text = $"{find}{SoraniBeh}";
             AssertSimpleSoraniNormalizer(text, find, replace);
         }
 
         private void AssertSimpleSoraniNormalizer(string text, char find, char replace)
         {
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
             Assert.True(normalized.Contains(replace));
             Assert.False(normalized.Contains(find));
         }
 
         [Theory]
-        [InlineData(ArabicLetterYeh, ArabicFatha)]                          // يَ => ێ
-        [InlineData(ArabicLetterAlefMaksura, ArabicFatha)]                  // ىَ => ێ
-        [InlineData(Beh, ArabicLetterYeh, ArabicFatha)]                     // بيَ => بێ
-        [InlineData(RehWithSmallV, ArabicLetterYeh, ArabicFatha, Zain)]     // ڕيَز => ڕێز
-        public void Should_Replace_Ye_Followed_By_Kasra_To_YeWithSmallV(params char[] chars)
+        [InlineData(ArabicYeh, ArabicFatha)]                                // يَ => ێ
+        [InlineData(ArabicAlefMaksura, ArabicFatha)]                        // ىَ => ێ
+        [InlineData(SoraniBeh, ArabicYeh, ArabicFatha)]                     // بيَ => بێ
+        [InlineData(SoraniHeavyReh, ArabicYeh, ArabicFatha, SoraniZeh)]     // ڕيَز => ڕێز
+        public void Should_Replace_Yeh_Followed_By_Kasra_To_OpenYeh(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(YehWithSmallV));
+            Assert.True(normalized.Contains(SoraniOpenYeh));
             Assert.False(normalized.Contains(ArabicFatha));
-            Assert.False(normalized.Contains(ArabicLetterYeh));
-            Assert.False(normalized.Contains(ArabicLetterAlefMaksura));
+            Assert.False(normalized.Contains(ArabicYeh));
+            Assert.False(normalized.Contains(ArabicAlefMaksura));
         }
 
         [Theory]
-        [InlineData(Waw, ArabicFatha)]                                      // وَ => ۆ
-        [InlineData(Waw, ArabicFatha)]                                      // ىَ => ۆ
-        [InlineData(Beh, Waw, ArabicFatha)]                                 // بوَ => بۆ
-        [InlineData(RehWithSmallV, Waw, ArabicFatha, Jeh)]                  // ڕوَژ => ڕۆژ
+        [InlineData(SoraniWaw, ArabicFatha)]                                      // وَ => ۆ
+        [InlineData(SoraniWaw, ArabicFatha)]                                      // ىَ => ۆ
+        [InlineData(SoraniBeh, SoraniWaw, ArabicFatha)]                           // بوَ => بۆ
+        [InlineData(SoraniHeavyReh, SoraniWaw, ArabicFatha, SoraniJeh)]           // ڕوَژ => ڕۆژ
 
-        [InlineData(ArabicLetterWawWithHamzaAbove)]                         // ؤ => ێ
-        [InlineData(Beh, ArabicLetterWawWithHamzaAbove)]                    // بؤ => بۆ
-        [InlineData(RehWithSmallV, ArabicLetterWawWithHamzaAbove, Jeh)]     // ڕؤژ => ڕۆژ
+        [InlineData(ArabicWawWithHamzaAbove)]                                     // ؤ => ێ
+        [InlineData(SoraniBeh, ArabicWawWithHamzaAbove)]                          // بؤ => بۆ
+        [InlineData(SoraniHeavyReh, ArabicWawWithHamzaAbove, SoraniJeh)]          // ڕؤژ => ڕۆژ
         public void Should_Replace_Waw_Followed_By_Fatha_To_Oe(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(Oe));
+            Assert.True(normalized.Contains(SoraniOe));
             Assert.False(normalized.Contains(ArabicFatha));
-            Assert.False(normalized.Contains(Waw));
-            Assert.False(normalized.Contains(ArabicLetterWawWithHamzaAbove));
+            Assert.False(normalized.Contains(SoraniWaw));
+            Assert.False(normalized.Contains(ArabicWawWithHamzaAbove));
         }
 
         [Theory]
-        [InlineData(Reh, ArabicKasra)]                          // رِ => ڕ
-        [InlineData(Beh, Reh, ArabicKasra)]                     // برِ => بڕ
-        [InlineData(Kaf, Reh, ArabicKasra, Yeh, Noon)]          // کرِین => کڕین
-        public void Should_Replace_Reh_Followed_By_Kasra_With_RehWithSmallV(params char[] chars)
+        [InlineData(SoraniReh, ArabicKasra)]                                        // رِ => ڕ
+        [InlineData(SoraniBeh, SoraniReh, ArabicKasra)]                             // برِ => بڕ
+        [InlineData(SoraniKaf, SoraniReh, ArabicKasra, SoraniYeh, SoraniNoon)]      // کرِین => کڕین
+        public void Should_Replace_Reh_Followed_By_Kasra_With_HeavyReh(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(RehWithSmallV));
+            Assert.True(normalized.Contains(SoraniHeavyReh));
             Assert.False(normalized.Contains(ArabicKasra));
-            Assert.False(normalized.Contains(Reh));
+            Assert.False(normalized.Contains(SoraniReh));
         }
 
         [Theory]
-        [InlineData(Kaf, Alef, Reh)]                                 // کار
-        [InlineData(Teh, Reh, Yeh, Sheen)]                           // تریش
+        [InlineData(SoraniKaf, SoraniAlef, SoraniReh)]                                 // کار
+        [InlineData(SoraniTeh, SoraniReh, SoraniYeh, SoraniSheen)]                     // تریش
         public void Should_Not_Replace_Reh_Not_Followed_By_Kasra(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(Reh));
-            Assert.False(normalized.Contains(RehWithSmallV));
+            Assert.True(normalized.Contains(SoraniReh));
+            Assert.False(normalized.Contains(SoraniHeavyReh));
         }
 
         [Theory]
-        [InlineData(Lam, ArabicFatha)]                          // لَ => ڵ
-        [InlineData(Beh, Ae, Lam, ArabicFatha, Alef, Meem)]     // بەلَام => بەڵام
-        public void Should_Replace_Lam_Followed_By_Fatha_With_LamWithSmallV(params char[] chars)
+        [InlineData(SoraniLam, ArabicFatha)]                                                // لَ => ڵ
+        [InlineData(SoraniBeh, SoraniAe, SoraniLam, ArabicFatha, SoraniAlef, SoraniMeem)]   // بەلَام => بەڵام
+        public void Should_Replace_Lam_Followed_By_Fatha_With_HeavyLam(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(LamWithSmallV));
+            Assert.True(normalized.Contains(SoraniHeavyLam));
             Assert.False(normalized.Contains(ArabicFatha));
-            Assert.False(normalized.Contains(Lam));
+            Assert.False(normalized.Contains(SoraniLam));
         }
 
         [Theory]
-        [InlineData(Lam, Alef, Reh)]                        // لار
+        [InlineData(SoraniLam, SoraniAlef, SoraniReh)]                        // لار
         public void Should_Not_Replace_Lam_Not_Followed_By_Fatha(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(Lam));
-            Assert.False(normalized.Contains(LamWithSmallV));
+            Assert.True(normalized.Contains(SoraniLam));
+            Assert.False(normalized.Contains(SoraniHeavyLam));
         }
 
         [Theory]
-        [InlineData(Hamza, Alef, Seen, Noon)]                       // ئاسان
-        [InlineData(Hamza, Ae, Noon, Jeem, Ae, Meem)]               // ئەنجام
+        [InlineData(SoraniHamza, SoraniAlef, SoraniSeen, SoraniNoon)]                       // ئاسان
+        [InlineData(SoraniHamza, SoraniAe, SoraniNoon, SoraniJeem, SoraniAe, SoraniMeem)]   // ئەنجام
         public void Should_Not_Replace_Hamza_Followed_By_Vowels(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(Hamza));
-            Assert.False(normalized.Contains(YehWithSmallV));
+            Assert.True(normalized.Contains(SoraniHamza));
+            Assert.False(normalized.Contains(SoraniOpenYeh));
         }
 
         [Theory]
-        [InlineData(Beh, Hamza)]                                // بئ => بێ
-        [InlineData(Beh, Hamza, Gaf, Waw, Meem, Alef, Noon)]    // بئگومان => بێگومان
-        public void Should_Replace_Hamza_Followed_By_Consonants_With_YehWithSmallV(params char[] chars)
+        [InlineData(SoraniBeh, SoraniHamza)]                                                              // بئ => بێ
+        [InlineData(SoraniBeh, SoraniHamza, SoraniGaf, SoraniWaw, SoraniMeem, SoraniAlef, SoraniNoon)]    // بئگومان => بێگومان
+        public void Should_Replace_Hamza_Followed_By_Consonants_With_OpenYeh(params char[] chars)
         {
             var text = new string(chars);
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.True(normalized.Contains(YehWithSmallV));
-            Assert.False(normalized.Contains(Hamza));
+            Assert.True(normalized.Contains(SoraniOpenYeh));
+            Assert.False(normalized.Contains(SoraniHamza));
         }
 
         [Fact] // ئئستا => ئێستا     
         public void Should_Replace_Second_Hamza_But_Not_First_Hamza()
         {
-            var text = $"{Hamza}{Hamza}{Seen}{Teh}{Alef}"; // ئێستا
+            var text = $"{SoraniHamza}{SoraniHamza}{SoraniSeen}{SoraniTeh}{SoraniAlef}"; // ئێستا
 
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.Equal(Hamza, normalized[0]);
-            Assert.Equal(YehWithSmallV, normalized[1]);
+            Assert.Equal(SoraniHamza, normalized[0]);
+            Assert.Equal(SoraniOpenYeh, normalized[1]);
         }
 
         [Theory]
@@ -217,7 +217,7 @@ namespace DevTree.BeKurdi.Tests
             var random = new Random();
 
             var space = includeSpace ? new char[] { Space } : new char[] { };
-            var ignoredChars = new char[] { ArabicLetterSad, ArabicKasra, ArabicFatha, ZeroWidthNonJoiner };
+            var ignoredChars = new char[] { ArabicSad, ArabicKasra, ArabicFatha, ZeroWidthNonJoiner };
             var troublesomeChars = NonStandardSoraniAlphabet.Except(ignoredChars);
             var charSet = troublesomeChars.Union(SoraniAlphabet)
                                           .Union(space)
@@ -227,7 +227,7 @@ namespace DevTree.BeKurdi.Tests
                                             .Select(set => set[random.Next(charSet.Length)]).ToArray());
 
             timer.Start();
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
             timer.Stop();
 
             Assert.True(timer.ElapsedMilliseconds < 1000);
@@ -237,11 +237,11 @@ namespace DevTree.BeKurdi.Tests
         [Fact]  // ازاد => ئازاد
         public void Should_Insert_Hamza_To_The_Begenning_Of_The_Words_That_Start_With_Aelf()
         {
-            var text = $"{Alef}{Zain}{Alef}{Dal}";  // ازاد
-            var normalized = SoraniNormalization.Normalize(text);
+            var text = $"{SoraniAlef}{SoraniZeh}{SoraniAlef}{SoraniDal}";  // ازاد
+            var normalized = Sorani.ToStandardSorani(text);
 
-            Assert.Equal(Hamza, normalized[0]);
-            Assert.Equal(Alef, normalized[1]);
+            Assert.Equal(SoraniHamza, normalized[0]);
+            Assert.Equal(SoraniAlef, normalized[1]);
         }
 
         [Fact]
@@ -251,7 +251,7 @@ namespace DevTree.BeKurdi.Tests
 
             var expected = "پێش هەولێر چووم بۆ سلێمانی. لەوێ چووم بۆ بازاڕ. زۆر شتی جوانم کڕی.";
 
-            var normalized = SoraniNormalization.Normalize(text);
+            var normalized = Sorani.ToStandardSorani(text);
 
             Assert.Equal(expected, normalized);
         }

--- a/tests/DevTree.BeKurdi.Tests/SoraniNormalizationTests.cs
+++ b/tests/DevTree.BeKurdi.Tests/SoraniNormalizationTests.cs
@@ -10,10 +10,24 @@ namespace DevTree.BeKurdi.Tests
 {
     public class SoraniNormalizationTests
     {
+        [Fact]
+        public void Should_Return_Empty_String_When_Given_Empty_String()
+        {
+            var normalized = SoraniNormalization.Normalize(string.Empty);
+            Assert.Equal(string.Empty, normalized);
+        }
+
+        [Fact]
+        public void Passing_Null_Should_Throw_Exception()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            SoraniNormalization.Normalize(null));
+        }
+
         [Theory]
         [InlineData(Reh)]                                   // ر => ڕ
         [InlineData(Reh, YehWithSmallV, Waw, Yeh)]          // رێوی => ڕێوی
-        public void Normalize_Initial_r_To_R(params char[] chars)
+        public void Should_Change_Initial_r_To_R(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -24,7 +38,7 @@ namespace DevTree.BeKurdi.Tests
         [Theory]
         [InlineData(Jeem, Alef, Reh)]                       // جار
         [InlineData(Seen, Ae, Reh, Dal, Alef, Reh)]         // سەردار
-        public void Normalize_Dont_Change_Medial_r_To_R(params char[] chars)
+        public void Should_Not_Change_Medial_r_To_R(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -46,7 +60,7 @@ namespace DevTree.BeKurdi.Tests
         [InlineData(ArabicLetterYeh, Yeh)]                              // ي => ی
         [InlineData(ArabicLetterAlefWithHamzaAbove, Alef)]              // أ => ا
         [InlineData(ArabicLetterAlefWithMaddaAbove, Alef)]              // آ => ا
-        public void Normalize_Simple_Chars(char find, char replace)
+        public void Should_Replace_Non_Standard_Char(char find, char replace)
         {
             var text = find.ToString();
             var normalized = SoraniNormalization.Normalize(text);
@@ -78,7 +92,7 @@ namespace DevTree.BeKurdi.Tests
         [InlineData(ArabicLetterAlefMaksura, ArabicFatha)]                  // ىَ => ێ
         [InlineData(Beh, ArabicLetterYeh, ArabicFatha)]                     // بيَ => بێ
         [InlineData(RehWithSmallV, ArabicLetterYeh, ArabicFatha, Zain)]     // ڕيَز => ڕێز
-        public void Normalize_Ye_With_SmallV(params char[] chars)
+        public void Should_Replace_Ye_Followed_By_Kasra_To_YeWithSmallV(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -98,7 +112,7 @@ namespace DevTree.BeKurdi.Tests
         [InlineData(ArabicLetterWawWithHamzaAbove)]                         // ؤ => ێ
         [InlineData(Beh, ArabicLetterWawWithHamzaAbove)]                    // بؤ => بۆ
         [InlineData(RehWithSmallV, ArabicLetterWawWithHamzaAbove, Jeh)]     // ڕؤژ => ڕۆژ
-        public void Normalize_Oe_With_SmallV(params char[] chars)
+        public void Should_Replace_Waw_Followed_By_Fatha_To_Oe(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -113,7 +127,7 @@ namespace DevTree.BeKurdi.Tests
         [InlineData(Reh, ArabicKasra)]                          // رِ => ڕ
         [InlineData(Beh, Reh, ArabicKasra)]                     // برِ => بڕ
         [InlineData(Kaf, Reh, ArabicKasra, Yeh, Noon)]          // کرِین => کڕین
-        public void Should_Add_Small_V_To_Reh_With_Fatha(params char[] chars)
+        public void Should_Replace_Reh_Followed_By_Kasra_With_RehWithSmallV(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -126,7 +140,7 @@ namespace DevTree.BeKurdi.Tests
         [Theory]
         [InlineData(Kaf, Alef, Reh)]                                 // کار
         [InlineData(Teh, Reh, Yeh, Sheen)]                           // تریش
-        public void Shouldnt_Add_Small_V_To_Reh_Without_Fatha(params char[] chars)
+        public void Should_Not_Replace_Reh_Not_Followed_By_Kasra(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -138,7 +152,7 @@ namespace DevTree.BeKurdi.Tests
         [Theory]
         [InlineData(Lam, ArabicFatha)]                          // لَ => ڵ
         [InlineData(Beh, Ae, Lam, ArabicFatha, Alef, Meem)]     // بەلَام => بەڵام
-        public void Should_Add_Small_V_To_Lam_With_Fatha(params char[] chars)
+        public void Should_Replace_Lam_Followed_By_Fatha_With_LamWithSmallV(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -150,7 +164,7 @@ namespace DevTree.BeKurdi.Tests
 
         [Theory]
         [InlineData(Lam, Alef, Reh)]                        // لار
-        public void Shouldnt_Add_Small_V_To_Lam_Withithout_Fatha(params char[] chars)
+        public void Should_Not_Replace_Lam_Not_Followed_By_Fatha(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -162,7 +176,7 @@ namespace DevTree.BeKurdi.Tests
         [Theory]
         [InlineData(Hamza, Alef, Seen, Noon)]                       // ئاسان
         [InlineData(Hamza, Ae, Noon, Jeem, Ae, Meem)]               // ئەنجام
-        public void Normalize_Hamza_With_Vowels(params char[] chars)
+        public void Should_Not_Replace_Hamza_Followed_By_Vowels(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -174,7 +188,7 @@ namespace DevTree.BeKurdi.Tests
         [Theory]
         [InlineData(Beh, Hamza)]                                // بئ => بێ
         [InlineData(Beh, Hamza, Gaf, Waw, Meem, Alef, Noon)]    // بئگومان => بێگومان
-        public void Normalize_Hamza_With_Consonants(params char[] chars)
+        public void Should_Replace_Hamza_Followed_By_Consonants_With_YehWithSmallV(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -184,7 +198,7 @@ namespace DevTree.BeKurdi.Tests
         }
 
         [Fact] // ئئستا => ئێستا     
-        public void Normalize_Hamza_With_Consonants_AtTheBeggining()
+        public void Should_Replace_Second_Hamza_But_Not_First_Hamza()
         {
             var text = $"{Hamza}{Hamza}{Seen}{Teh}{Alef}"; // ئێستا
 
@@ -221,7 +235,7 @@ namespace DevTree.BeKurdi.Tests
         }
 
         [Fact]  // ازاد => ئازاد
-        public void Normalize_Aelf_At_The_Begenning_Of_A_Word()
+        public void Should_Insert_Hamza_To_The_Begenning_Of_The_Words_That_Start_With_Aelf()
         {
             var text = $"{Alef}{Zain}{Alef}{Dal}";  // ازاد
             var normalized = SoraniNormalization.Normalize(text);

--- a/tests/DevTree.BeKurdi.Tests/SoraniNormalizationTests.cs
+++ b/tests/DevTree.BeKurdi.Tests/SoraniNormalizationTests.cs
@@ -18,7 +18,7 @@ namespace DevTree.BeKurdi.Tests
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
 
-            Assert.True(normalized[0] == RehWithSmallV);
+            Assert.Equal(RehWithSmallV, normalized[0]);
         }
 
         [Theory]
@@ -29,7 +29,7 @@ namespace DevTree.BeKurdi.Tests
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
 
-            Assert.True(normalized == text);
+            Assert.Equal(text, normalized);
         }
 
         [Theory]
@@ -113,7 +113,7 @@ namespace DevTree.BeKurdi.Tests
         [InlineData(Reh, ArabicKasra)]                          // رِ => ڕ
         [InlineData(Beh, Reh, ArabicKasra)]                     // برِ => بڕ
         [InlineData(Kaf, Reh, ArabicKasra, Yeh, Noon)]          // کرِین => کڕین
-        public void Normalize_Reh_With_SmallV(params char[] chars)
+        public void Should_Add_Small_V_To_Reh_With_Fatha(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
@@ -124,19 +124,39 @@ namespace DevTree.BeKurdi.Tests
         }
 
         [Theory]
-        [InlineData(Heh, ZeroWidthNonJoiner)]
-        [InlineData(Space, Heh, ZeroWidthNonJoiner)]
-        [InlineData(Heh, ZeroWidthNonJoiner, Space)]
-        [InlineData(Beh, Heh, ZeroWidthNonJoiner)]                  // بە
-        [InlineData(Dal, Heh, ZeroWidthNonJoiner, Seen, Teh)]       // دەست
-        public void Normalize_Heh_With_Zer_Width_Non_Joiner(params char[] chars)
+        [InlineData(Kaf, Alef, Reh)]                                 // کار
+        [InlineData(Teh, Reh, Yeh, Sheen)]                           // تریش
+        public void Shouldnt_Add_Small_V_To_Reh_Without_Fatha(params char[] chars)
         {
             var text = new string(chars);
             var normalized = SoraniNormalization.Normalize(text);
 
-            Assert.True(normalized.Contains(Ae));
-            Assert.False(normalized.Contains(Heh));
-            Assert.False(normalized.Contains(ZeroWidthNonJoiner));
+            Assert.True(normalized.Contains(Reh));
+            Assert.False(normalized.Contains(RehWithSmallV));
+        }
+
+        [Theory]
+        [InlineData(Lam, ArabicFatha)]                          // لَ => ڵ
+        [InlineData(Beh, Ae, Lam, ArabicFatha, Alef, Meem)]     // بەلَام => بەڵام
+        public void Should_Add_Small_V_To_Lam_With_Fatha(params char[] chars)
+        {
+            var text = new string(chars);
+            var normalized = SoraniNormalization.Normalize(text);
+
+            Assert.True(normalized.Contains(LamWithSmallV));
+            Assert.False(normalized.Contains(ArabicFatha));
+            Assert.False(normalized.Contains(Lam));
+        }
+
+        [Theory]
+        [InlineData(Lam, Alef, Reh)]                        // لار
+        public void Shouldnt_Add_Small_V_To_Lam_Withithout_Fatha(params char[] chars)
+        {
+            var text = new string(chars);
+            var normalized = SoraniNormalization.Normalize(text);
+
+            Assert.True(normalized.Contains(Lam));
+            Assert.False(normalized.Contains(LamWithSmallV));
         }
 
         [Theory]
@@ -170,8 +190,8 @@ namespace DevTree.BeKurdi.Tests
 
             var normalized = SoraniNormalization.Normalize(text);
 
-            Assert.True(normalized[0] == Hamza);
-            Assert.True(normalized[1] == YehWithSmallV);
+            Assert.Equal(Hamza, normalized[0]);
+            Assert.Equal(YehWithSmallV, normalized[1]);
         }
 
         [Theory]
@@ -206,8 +226,20 @@ namespace DevTree.BeKurdi.Tests
             var text = $"{Alef}{Zain}{Alef}{Dal}";  // ازاد
             var normalized = SoraniNormalization.Normalize(text);
 
-            Assert.True(normalized[0] == Hamza);
-            Assert.True(normalized[1] == Alef);
+            Assert.Equal(Hamza, normalized[0]);
+            Assert.Equal(Alef, normalized[1]);
+        }
+
+        [Fact]
+        public void Normalize_A_Sentence()
+        {
+            var text = "ثيَش هةوليَر ضووم بؤ سليَماني. لةويَ ضووم بؤ بازارِ. زؤر شتي جوانم كرِي.";
+
+            var expected = "پێش هەولێر چووم بۆ سلێمانی. لەوێ چووم بۆ بازاڕ. زۆر شتی جوانم کڕی.";
+
+            var normalized = SoraniNormalization.Normalize(text);
+
+            Assert.Equal(expected, normalized);
         }
     }
 }


### PR DESCRIPTION
These changes have been made:
 - The characters in standard Sorani alphabet all have a `Sorani` prefix.
 - Remove `Letter` from the names of the non-standard characters
 - Rename `SoraniNormalization` class to `Sorani`
 - Renamed the testes to reflect the name changes
 - Fixed a bug where `SoraniLam` + `ArabicKasra` wouldn't be replaced by `SoraniHeavyLam`